### PR TITLE
Fix bug with diffs not opening on windows

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,7 @@ var projectRoot = vscode.workspace.rootPath;
 var simpleGit = require('simple-git')((projectRoot) ? projectRoot : '.');
 var childProcess = require('child_process');
 var fs = require('fs');
+var os = require('os');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -339,9 +340,12 @@ function activate(context) {
                 } else {
                     simpleGit.diff([result.label, ], function (error, result) {
                         if (error) throw error;
-                        fs.writeFile('/tmp/.git-easy.diff', result, (err) => {
+
+                        var diffFile = os.tmpdir() + "/.git-easy.diff";
+
+                        fs.writeFile(diffFile, result, (err) => {
                             if (err) throw err;
-                            vscode.workspace.openTextDocument('/tmp/.git-easy.diff')
+                            vscode.workspace.openTextDocument(diffFile)
                                 .then(function (file) {
                                     vscode.window.showTextDocument(file, vscode.ViewColumn.Two, false);
                                 });


### PR DESCRIPTION
The `/tmp` directory was hardcoded which doesn't exist on windows. The fix uses the `tmpDir()` function in the `os` package to get a definitive "temp" directory across platforms

API: https://nodejs.org/api/os.html#os_os_tmpdir

Also, YOU CAN HAZ A GIF:

![giteasy_pr1](https://cloud.githubusercontent.com/assets/240368/19346778/c9c2dd0a-9162-11e6-967c-176f2c685e76.gif)

---

Note: I haven't tested this functionality on a linux / OSX box since I don't have any at hand. So that part is pending.
